### PR TITLE
Copy month all work and result files

### DIFF
--- a/rim_post_dump.R
+++ b/rim_post_dump.R
@@ -76,7 +76,7 @@ suffix_multiple_months <- ""
 
 # Suffix to add at the end of the export file name. This suffix will be added to
 # the end of the file name with a "_" as separation.
-suffix <- "TEST"
+suffix <- ""
 
 # cfpo to use in the script
 cfpo_to_use <- "CFPO2024 DEF.xlsx"
@@ -92,14 +92,9 @@ library(openxlsx) # to read directly CFPO from a excel file
 # install sapmuebase from github
 # remove.packages("sapmuebase")
 # .rs.restartR()
-#install_github("eucrow/sapmuebase")
+# install_github("eucrow/sapmuebase")
 
 library(sapmuebase)
-
-# install archive package 
-# install.package("archive")
-
-library(archive)
 
 # FUNCTIONS --------------------------------------------------------------------
 
@@ -267,10 +262,6 @@ rstudioapi::documentSaveAll()
 sapmuebase::backupScripts(FILES_TO_BACKUP, path_backup = PATH_BACKUP)
 
 # SAVE FILES TO SHARED FOLDER --------------------------------------------------
-
-# lapply(list(PATH_INPUT_FILES, PATH_BACKUP, PATH_ERRORS), 
-# copyFilesToFolder, 
-# PATH_SHARE_ERRORS)
 
 copyFilesToFolder(PATH_FILES, PATH_SHARE_ERRORS)
 

--- a/rim_post_dump.R
+++ b/rim_post_dump.R
@@ -76,7 +76,7 @@ suffix_multiple_months <- ""
 
 # Suffix to add at the end of the export file name. This suffix will be added to
 # the end of the file name with a "_" as separation.
-suffix <- ""
+suffix <- "TEST"
 
 # cfpo to use in the script
 cfpo_to_use <- "CFPO2024 DEF.xlsx"
@@ -268,11 +268,11 @@ sapmuebase::backupScripts(FILES_TO_BACKUP, path_backup = PATH_BACKUP)
 
 # SAVE FILES TO SHARED FOLDER --------------------------------------------------
 
-lapply(list(PATH_INPUT_FILES, PATH_BACKUP, PATH_ERRORS), 
-copyFilesToFolder, 
-PATH_SHARE_ERRORS)
+# lapply(list(PATH_INPUT_FILES, PATH_BACKUP, PATH_ERRORS), 
+# copyFilesToFolder, 
+# PATH_SHARE_ERRORS)
 
-copyFilesToFolder(PATH_ERRORS, PATH_SHARE_ERRORS)
+copyFilesToFolder(PATH_FILES, PATH_SHARE_ERRORS)
 
 # SEND EMAILS AUTOMATICALLY ----------------------------------------------------
 # The first time the errors will be sent by email, a credential file must be

--- a/rim_post_dump.R
+++ b/rim_post_dump.R
@@ -65,7 +65,7 @@ source(file.path(PRIVATE_FOLDER_NAME, ("user_settings.R")))
 # FILENAME_TAL <- "IEOUPMUETALSIRENO.TXT"
 
 # MONTH: 1 to 12, or vector with month in numbers
-MONTH <- c(5)
+MONTH <- c(9)
 
 # YEAR
 YEAR <- 2025
@@ -96,6 +96,10 @@ library(openxlsx) # to read directly CFPO from a excel file
 
 library(sapmuebase)
 
+# install archive package 
+# install.package("archive")
+
+library(archive)
 
 # FUNCTIONS --------------------------------------------------------------------
 
@@ -255,9 +259,6 @@ exportErrorsList(errors, ERRORS_FILENAME, separation = "_")
 # This check is not for send to the sups, so it's out the ERRORS dataframe
 # errors_cod_id <- checkCodId(muestreos_up$catches)
 
-# SAVE FILES TO SHARED FOLDER --------------------------------------------------
-copyFilesToFolder(PATH_ERRORS, PATH_SHARE_ERRORS)
-
 
 # BACKUP SCRIPTS AND RELATED FILES ---------------------------------------------
 # first save all files opened
@@ -265,6 +266,13 @@ rstudioapi::documentSaveAll()
 # and the backup the scripts and files:
 sapmuebase::backupScripts(FILES_TO_BACKUP, path_backup = PATH_BACKUP)
 
+# SAVE FILES TO SHARED FOLDER --------------------------------------------------
+
+lapply(list(PATH_INPUT_FILES, PATH_BACKUP, PATH_ERRORS), 
+copyFilesToFolder, 
+PATH_SHARE_ERRORS)
+
+copyFilesToFolder(PATH_ERRORS, PATH_SHARE_ERRORS)
 
 # SEND EMAILS AUTOMATICALLY ----------------------------------------------------
 # The first time the errors will be sent by email, a credential file must be
@@ -283,10 +291,10 @@ sapmuebase::backupScripts(FILES_TO_BACKUP, path_backup = PATH_BACKUP)
 # - NOTES: any notes to add to the email. If there aren't, must be set to "".
 accesory_email_info <- data.frame(
   AREA_INF = c("AC", "GC", "GN", "GS"),
-  LINK = c("", 
-           "", 
-           "", 
-           ""),
+  LINK = c("https://saco.csic.es/index.php/f/625892378", 
+           "https://saco.csic.es/index.php/f/625892370", 
+           "https://saco.csic.es/index.php/f/625892384", 
+           "https://saco.csic.es/index.php/f/625892374"),
   NOTES = c("", 
             "", 
             "", 

--- a/rim_post_dump_auxiliary_functions.R
+++ b/rim_post_dump_auxiliary_functions.R
@@ -278,10 +278,10 @@ copyFilesToFolder <- function (path_files_from, path_files_to){
   # test if there are files with the same name in folder. In this case,
   # nothing is saved.
   files_list_to <- list.files(path_files_to,
-                             recursive = TRUE)
+                              recursive = TRUE)
 
   files_list_from <- list.files(path_files_from,
-                             recursive = TRUE)
+                                recursive = TRUE)
     
   if(any(files_list_from %in% files_list_to)){
     ae <- which(files_list_from %in% files_list_to)
@@ -326,8 +326,6 @@ createMonthAsCharacter <- function(month = MONTH, suffix_multiple_months = suffi
   }
 
 }
-
-
 
 
 #' Create identifier of the month/months, with suffix. Used to create the filenames


### PR DESCRIPTION
The next modifications where done:

-Changes on copyFilesToFolder functions to make a copy on the share error's directory to save not only the analysis error files, also the input and backup one's. As well, the body of the function was inserted in a try-catch block. 

-Modification on the arguments used on the main script (rim_post_dump.R), changing PATH_ERROR for PATH_FILES. 